### PR TITLE
초성 검색 여부 적용, 한글판단 함수에 ALL/One or more 옵션 적용

### DIFF
--- a/examples/search.html
+++ b/examples/search.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="text/javascript" src='http://code.jquery.com/jquery-latest.min.js'></script>
+<script type="text/javascript" src='../hangul.js'></script>
+<script type="text/javascript">
+function doDisassemble(){
+	var r = Hangul.disassemble($('#hangul_text').val().trim(), false);
+	$('#hangul_disassembled').text(r.join(''));
+	return r;
+}
+function doDisassembleCho(){
+	var r = Hangul.disassemble($('#hangul_text').val().trim(), true).map(function(t){return t[0];});
+	$('#hangul_disassembled').text(r.join(''));
+	return r;
+}
+function doSearch(){
+	var t = $('#hangul_text').val();
+	var r1 = Hangul.rangeSearch(t, $('#hangul_search').val(), $(":input:radio[name=hangul_searchCho]:checked").val() == 'on' );
+	var r2 = r1.map(function(a){return t.substr(a[0], a[1]-a[0]+1);})
+	$('#hangul_searched').text(r2);
+	return r1;
+}
+</script>
+</head>
+<body>
+	<div>
+		<textarea id="hangul_text" rows="10" cols="100">세종어제 훈민정음나라 말이 중국과 달라문자와는 서로 맞지 아니해서이런 까닭으로 어리석은 백성이 이르고자 할 바 있어도마침내 제 뜻을 능히 펴지 못한 사람이 많으니라내 이를 위하여 가엾이 여겨새로 스물여덟 자를 만드노니사람마다 하여 쉬이 익혀 날로 쓰며 편안케 하고자 할 따름이니라</textarea>
+		<a href="javascript:doDisassemble()">disassemble</a>
+		<a href="javascript:doDisassembleCho()">초성</a>
+		<div id="hangul_disassembled"></div>
+	</div>
+	<div>
+		<input id="hangul_search" type="text" value="ㅂㅅ"/>
+		초성검색 : 
+		<input name="hangul_searchCho" type="radio" value="on" checked/>On
+		<input name="hangul_searchCho" type="radio" value="off" />Off
+		<br/>
+		<a href="javascript:doSearch()">search</a>
+		<div id="hangul_searched"></div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
Git에 익숙하지 않아 pull request가 이렇게 하는게 맞는건지 잘 모르겠네요.
search 함수에 초성 검색 기능 추가와 한글 판단 함수에 string 값에 대해 전체 비교를 통해 전체가 true 일 경우와 전체 중 하나라도 true 일 경우를 판단하는 옵션을 적용 했습니다.
기존 함수들에 파라미터를 하나씩 추가하는 형태로 구현했는데... 최대한 기존 함수를 그대로 사용하여도 이상이 없도록 만들었습니다.
수정 된 것은 아래 내욫 참고하시기 바랍니다.

ㅇ 초성 검색 여부 적용
기존 search 함수에 초성 검색 여부 추가
초성 검색 여부가 true 이고 입력값 b가 자음으로만 구성되어 있을 경우 초성검색 실행. 그렇지 않을 경우 기존 search
함수 실행.

Hangul.search(a, b) -> Hangul.search(a, b, cho)
Hangul.rangeSearch(a, b) -> Hangul.rangeSearch(a, b, cho)
Hangul.Searcher(b) -> Hangul.Searcher(b, cho)

ㅇ 한글판단 함수에 ALL/One or more 옵션 적용
기존 한글 판단 함수에 옵션값 추가
ASIS : 
- 파라미터가 string 일 경우 첫번째 문자 참일 경우 true.
TOBE : 
- 옵션값이 'ALL' 일 경우 모든 문자 참일 경우 true.
- 옵션값이 'ONE' 일 경우 하나의 문자 이상 참일 경우 true.

Hangul.isHangul(c) = Hangul.isHangul(c, o)
Hangul.isComplete(c) = Hangul.isComplete(c, o)
Hangul.isConsonant(c) = Hangul.isConsonant(c, o)
Hangul.isVowel(c) = Hangul.isVowel(c, o)
Hangul.isCho(c) = Hangul.isCho(c, o)
Hangul.isJong(c) = Hangul.isJong(c, o)