### PR TITLE
set charset utf-8 at examples html files

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,6 +4,7 @@
     <title>Hangul.js 예제</title>
     <script src="../hangul.js"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <meta charset='utf-8'>
     <style>
       section{padding: 20px 0px;}
     </style>

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
     <title>Hangul.js 예제</title>
     <script src="../hangul.js"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <style>
       section{padding: 20px 0px;}
     </style>

--- a/examples/stronger.html
+++ b/examples/stronger.html
@@ -4,6 +4,7 @@
     <title>Hangul.js 된소리 예제</title>
     <script src="../hangul.js"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <meta charset='utf-8'>
   </head>
   <body>
     <div class="container">

--- a/examples/stronger.html
+++ b/examples/stronger.html
@@ -4,7 +4,7 @@
     <title>Hangul.js 된소리 예제</title>
     <script src="../hangul.js"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
I set charset 'utf-8' at examples html files because Hangul in html files is broken in Internet Explorer.